### PR TITLE
Add Verified Recovery Secret Credential

### DIFF
--- a/docs/VerifiedRecoverySecretCredential/README.md
+++ b/docs/VerifiedRecoverySecretCredential/README.md
@@ -1,0 +1,18 @@
+# Verified Recovery Secret Credential
+
+Used to communicate the Frequency Recovery Secret in a standard way.
+
+## Fields
+
+### `recoverySecret`
+
+The human-readable form of the Recovery Secret.
+It should be all uppercase in the range: 0-9, A-F (hexadecimal).
+Total of 64 characters with chunks of 4 characters separated by `-`.
+
+Example: `69EC-2382-E1E6-76F3-341F-3414-9DD5-CFA5-6932-E418-9385-0358-31DF-AFEA-9828-D3B7`
+
+## Resources
+
+- [Frequency Design Document for the Recovery System](https://github.com/frequency-chain/frequency/blob/main/designdocs/recovery_system.md)
+- [Recovery JavaScript SDK](https://github.com/frequency-chain/frequency/tree/main/js/recovery-sdk#readme)

--- a/docs/VerifiedRecoverySecretCredential/bciqkdbqbqaiftbxlglg6xw5x2g6wfo7r5o7eqfr5ty2eojee4sjngja.json
+++ b/docs/VerifiedRecoverySecretCredential/bciqkdbqbqaiftbxlglg6xw5x2g6wfo7r5o7eqfr5ty2eojee4sjngja.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "VerifiedRecoverySecretCredential",
+  "type": "object",
+  "properties": {
+    "credentialSubject": {
+      "type": "object",
+      "properties": {
+        "recoverySecret": {
+          "type": "string"
+        }
+      },
+      "required": ["recoverySecret"]
+    }
+  }
+}

--- a/docs/VerifiedRecoverySecretCredential/bciqpg6qm4rnu2j4v6ghxqqgwkggokwvxs3t2bexbd3obkypkiryylxq.json
+++ b/docs/VerifiedRecoverySecretCredential/bciqpg6qm4rnu2j4v6ghxqqgwkggokwvxs3t2bexbd3obkypkiryylxq.json
@@ -7,7 +7,8 @@
       "type": "object",
       "properties": {
         "recoverySecret": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^[0-9A-F]{4}(-[0-9A-F]{4}){15}$"
         }
       },
       "required": ["recoverySecret"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,6 @@ Schema documents hosted here are assigned URL paths based on the `title` propert
 | --- | --- |
 | [VerifiedEmailAddressCredential](./VerifiedEmailAddressCredential/bciqe4qoczhftici4dzfvfbel7fo4h4sr5grco3oovwyk6y4ynf44tsi.json) | `bciqe4qoczhftici4dzfvfbel7fo4h4sr5grco3oovwyk6y4ynf44tsi` |
 | [VerifiedGraphKeyCredential](./VerifiedGraphKeyCredential/bciqmdvmxd54zve5kifycgsdtoahs5ecf4hal2ts3eexkgocyc5oca2y.json) | `bciqmdvmxd54zve5kifycgsdtoahs5ecf4hal2ts3eexkgocyc5oca2y` |
-| [VerifiedRecoverySecretCredential](./VerifiedRecoverySecretCredential/bciqkdbqbqaiftbxlglg6xw5x2g6wfo7r5o7eqfr5ty2eojee4sjngja.json) | `bciqkdbqbqaiftbxlglg6xw5x2g6wfo7r5o7eqfr5ty2eojee4sjngja` |
+| [VerifiedRecoverySecretCredential](./VerifiedRecoverySecretCredential/bciqpg6qm4rnu2j4v6ghxqqgwkggokwvxs3t2bexbd3obkypkiryylxq.json) | `bciqpg6qm4rnu2j4v6ghxqqgwkggokwvxs3t2bexbd3obkypkiryylxq` |
 | [VerifiedPhoneNumberCredential](./VerifiedPhoneNumberCredential/bciqjspnbwpc3wjx4fewcek5daysdjpbf5xjimz5wnu5uj7e3vu2uwnq.json) | `bciqjspnbwpc3wjx4fewcek5daysdjpbf5xjimz5wnu5uj7e3vu2uwnq` |
 | [ApplicationContextCredential](./ApplicationContextCredential/bciqe2bsnuaqg7zy3gqjmwha2q5h2bybvr6log2jsb5kjn2hos6irrlq.json) | `bciqe2bsnuaqg7zy3gqjmwha2q5h2bybvr6log2jsb5kjn2hos6irrlq` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,5 +11,6 @@ Schema documents hosted here are assigned URL paths based on the `title` propert
 | --- | --- |
 | [VerifiedEmailAddressCredential](./VerifiedEmailAddressCredential/bciqe4qoczhftici4dzfvfbel7fo4h4sr5grco3oovwyk6y4ynf44tsi.json) | `bciqe4qoczhftici4dzfvfbel7fo4h4sr5grco3oovwyk6y4ynf44tsi` |
 | [VerifiedGraphKeyCredential](./VerifiedGraphKeyCredential/bciqmdvmxd54zve5kifycgsdtoahs5ecf4hal2ts3eexkgocyc5oca2y.json) | `bciqmdvmxd54zve5kifycgsdtoahs5ecf4hal2ts3eexkgocyc5oca2y` |
+| [VerifiedRecoverySecretCredential](./VerifiedRecoverySecretCredential/bciqkdbqbqaiftbxlglg6xw5x2g6wfo7r5o7eqfr5ty2eojee4sjngja.json) | `bciqkdbqbqaiftbxlglg6xw5x2g6wfo7r5o7eqfr5ty2eojee4sjngja` |
 | [VerifiedPhoneNumberCredential](./VerifiedPhoneNumberCredential/bciqjspnbwpc3wjx4fewcek5daysdjpbf5xjimz5wnu5uj7e3vu2uwnq.json) | `bciqjspnbwpc3wjx4fewcek5daysdjpbf5xjimz5wnu5uj7e3vu2uwnq` |
 | [ApplicationContextCredential](./ApplicationContextCredential/bciqe2bsnuaqg7zy3gqjmwha2q5h2bybvr6log2jsb5kjn2hos6irrlq.json) | `bciqe2bsnuaqg7zy3gqjmwha2q5h2bybvr6log2jsb5kjn2hos6irrlq` |


### PR DESCRIPTION
See Readme in the commit for more details on the Recovery Secret.

Alternatives rejected:
- Having an "encoding" field as well as an "encodedRecoverySecret"
    - Rejected as the Recovery Secret is formatted like this. There is no "other" formatting. (Although technically at the end of the day it is just bytes)
- Calling it the `FrequencyRecoverySecret`
    - Rejected as just too verbose, although willing to bring it back if anyone wants it.
- Adding Readmes to the other verified credentials in here
    - Out of scope.